### PR TITLE
Fixed link to CSS Multiple Backgrounds

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -299,7 +299,7 @@
                     <article>
                         <h1>Multiple Backgrounds</h1>
                         <p>You can apply multiple backgrounds to elements. These are layered atop one another with the first background you provide on top and the last background displayed in the back.</p>
-                        <a href="https://developer.mozilla.org/en/Using_gradients" title="documentation">learn more</a>
+                        <a href="https://developer.mozilla.org/en/CSS/Multiple_backgrounds" title="documentation">learn more</a>
                     </article>
 
                     <article class="xxxie" id="columndemo">


### PR DESCRIPTION
It was pointing to: https://developer.mozilla.org/en/Using_gradients

It's now pointing to: https://developer.mozilla.org/en/CSS/Multiple_backgrounds

Probably less work for you to just fix the link than merge this change, but here's the pull request anyways.
